### PR TITLE
Replace DreamsTour branding with Antalya Tourbox logo

### DIFF
--- a/client/components/site/Footer.tsx
+++ b/client/components/site/Footer.tsx
@@ -6,11 +6,16 @@ export default function Footer() {
       <div className="container max-w-7xl container-px py-10">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-10">
           <div>
-            <div className="flex items-center gap-2 font-extrabold text-xl">
-              <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary text-white">
-                DT
-              </span>
-              Dreams<span className="text-primary">Tour</span>
+            <div className="flex items-center gap-2">
+              <img
+                src="https://antalyatourbox.com/image/cache/catalog/yeni-logo-400x84.png.webp"
+                alt="Antalya Tourbox"
+                className="h-9 w-auto"
+                width={120}
+                height={25}
+                loading="lazy"
+                decoding="async"
+              />
             </div>
             <p className="mt-4 text-sm text-slate-600">
               Dünyanın dört bir yanındaki eşsiz destinasyonları keşfedin.
@@ -84,7 +89,7 @@ export default function Footer() {
         </div>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-between gap-4 border-t pt-6 text-sm text-slate-500">
-          <p>© {new Date().getFullYear()} DreamsTour. Tüm Hakları Saklıdır.</p>
+          <p>© {new Date().getFullYear()} Antalya Tourbox. Tüm Hakları Saklıdır.</p>
           <div className="flex items-center gap-4">
             <Link to="#" className="hover:text-slate-700">
               Twitter

--- a/client/components/site/Footer.tsx
+++ b/client/components/site/Footer.tsx
@@ -89,7 +89,9 @@ export default function Footer() {
         </div>
 
         <div className="mt-10 flex flex-col sm:flex-row items-center justify-between gap-4 border-t pt-6 text-sm text-slate-500">
-          <p>© {new Date().getFullYear()} Antalya Tourbox. Tüm Hakları Saklıdır.</p>
+          <p>
+            © {new Date().getFullYear()} Antalya Tourbox. Tüm Hakları Saklıdır.
+          </p>
           <div className="flex items-center gap-4">
             <Link to="#" className="hover:text-slate-700">
               Twitter

--- a/client/components/site/Header.tsx
+++ b/client/components/site/Header.tsx
@@ -18,7 +18,11 @@ export default function Header() {
       <div className="container max-w-7xl container-px">
         <div className="flex h-16 items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <Link to="/" className="flex items-center gap-2" aria-label="Antalya Tourbox anasayfa">
+            <Link
+              to="/"
+              className="flex items-center gap-2"
+              aria-label="Antalya Tourbox anasayfa"
+            >
               <img
                 src="https://antalyatourbox.com/image/cache/catalog/yeni-logo-400x84.png.webp"
                 alt="Antalya Tourbox"

--- a/client/components/site/Header.tsx
+++ b/client/components/site/Header.tsx
@@ -18,13 +18,16 @@ export default function Header() {
       <div className="container max-w-7xl container-px">
         <div className="flex h-16 items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <Link to="/" className="flex items-center gap-2">
-              <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-primary text-white font-bold">
-                DT
-              </span>
-              <span className="text-xl font-extrabold tracking-tight text-slate-900">
-                Dreams<span className="text-primary">Tour</span>
-              </span>
+            <Link to="/" className="flex items-center gap-2" aria-label="Antalya Tourbox anasayfa">
+              <img
+                src="https://antalyatourbox.com/image/cache/catalog/yeni-logo-400x84.png.webp"
+                alt="Antalya Tourbox"
+                className="h-9 w-auto"
+                width={120}
+                height={25}
+                loading="eager"
+                decoding="async"
+              />
             </Link>
           </div>
 

--- a/client/components/site/Hero.tsx
+++ b/client/components/site/Hero.tsx
@@ -27,7 +27,16 @@ export default function Hero({
   }, [imgs.length]);
 
   return (
-    <section className="relative h-[350px]">
+    <section
+      className="relative h-[350px]"
+      style={{
+        backgroundImage:
+          "url(https://images.unsplash.com/photo-1507525428034-b723cf961d3e?q=85&w=2400&auto=format&fit=crop)",
+        backgroundRepeat: "no-repeat",
+        backgroundPosition: "center",
+        backgroundSize: "cover",
+      }}
+    >
       {/* Background slider */}
       <div className="absolute inset-0 -z-10">
         <div className="relative h-full w-full overflow-hidden">

--- a/client/global.css
+++ b/client/global.css
@@ -14,86 +14,86 @@
   :root {
     /* Light theme */
     --background: 0 0% 100%;
-    --foreground: 222 47% 11%;
+    --foreground: 0 0% 10%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222 47% 11%;
+    --card-foreground: 0 0% 10%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 11%;
+    --popover-foreground: 0 0% 10%;
 
-    /* Brand: azure blue */
-    --primary: 217 90% 55%;
+    /* Brand: red / black / white */
+    --primary: 0 72% 50%;
     --primary-foreground: 0 0% 100%;
 
-    /* Sub/neutral */
-    --secondary: 210 40% 96%;
-    --secondary-foreground: 222 47% 11%;
+    /* Sub/neutral in grayscale */
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 0 0% 10%;
 
-    /* Accents: sunset orange for CTAs */
-    --accent: 24 95% 54%;
+    /* Accents use primary red for CTAs */
+    --accent: 0 72% 50%;
     --accent-foreground: 0 0% 100%;
 
-    --muted: 210 40% 96%;
-    --muted-foreground: 215 16% 47%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 40%;
 
     --destructive: 0 72% 50%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 217 90% 55%;
+    --border: 0 0% 86%;
+    --input: 0 0% 86%;
+    --ring: 0 72% 50%;
 
     --radius: 0.75rem;
 
     /* Sidebar palette (if used) */
     --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5% 26%;
-    --sidebar-primary: 217 90% 55%;
+    --sidebar-foreground: 0 0% 10%;
+    --sidebar-primary: 0 72% 50%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 5% 96%;
-    --sidebar-accent-foreground: 240 6% 10%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 217 91% 60%;
+    --sidebar-accent: 0 0% 96%;
+    --sidebar-accent-foreground: 0 0% 10%;
+    --sidebar-border: 0 0% 86%;
+    --sidebar-ring: 0 72% 55%;
   }
 
   .dark {
-    --background: 222 47% 6%;
-    --foreground: 210 40% 96%;
+    --background: 0 0% 6%;
+    --foreground: 0 0% 96%;
 
-    --card: 222 47% 8%;
-    --card-foreground: 210 40% 96%;
+    --card: 0 0% 8%;
+    --card-foreground: 0 0% 96%;
 
-    --popover: 222 47% 8%;
-    --popover-foreground: 210 40% 96%;
+    --popover: 0 0% 8%;
+    --popover-foreground: 0 0% 96%;
 
-    --primary: 213 90% 60%;
+    --primary: 0 72% 60%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 217 33% 18%;
-    --secondary-foreground: 210 40% 96%;
+    --secondary: 0 0% 14%;
+    --secondary-foreground: 0 0% 96%;
 
-    --muted: 217 33% 18%;
-    --muted-foreground: 215 20% 65%;
+    --muted: 0 0% 14%;
+    --muted-foreground: 0 0% 70%;
 
-    --accent: 24 95% 54%;
+    --accent: 0 72% 60%;
     --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 63% 31%;
-    --destructive-foreground: 210 40% 96%;
+    --destructive: 0 72% 45%;
+    --destructive-foreground: 0 0% 96%;
 
-    --border: 217 33% 18%;
-    --input: 217 33% 18%;
-    --ring: 213 90% 60%;
+    --border: 0 0% 14%;
+    --input: 0 0% 14%;
+    --ring: 0 72% 60%;
 
-    --sidebar-background: 240 6% 10%;
-    --sidebar-foreground: 240 5% 96%;
-    --sidebar-primary: 224 76% 48%;
+    --sidebar-background: 0 0% 8%;
+    --sidebar-foreground: 0 0% 96%;
+    --sidebar-primary: 0 72% 60%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 4% 16%;
-    --sidebar-accent-foreground: 240 5% 96%;
-    --sidebar-border: 240 4% 16%;
-    --sidebar-ring: 217 91% 60%;
+    --sidebar-accent: 0 0% 16%;
+    --sidebar-accent-foreground: 0 0% 96%;
+    --sidebar-border: 0 0% 16%;
+    --sidebar-ring: 0 72% 60%;
   }
 }
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -195,7 +195,7 @@ export default function Index() {
             className="h-full w-full object-cover"
             loading="eager"
           />
-          <div className="absolute inset-0 bg-gradient-to-r from-rose-600/60 via-red-500/40 to-orange-500/60" />
+          <div className="absolute inset-0 bg-gradient-to-r from-red-700/70 via-red-600/60 to-black/60" />
         </div>
         <div className="container max-w-7xl container-px py-14 text-white">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -187,8 +187,8 @@ export default function Index() {
         </div>
       </section>
 
-      <section className="relative">
-        <div className="absolute inset-0 -z-10">
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 z-0">
           <img
             src="https://images.pexels.com/photos/1706725/pexels-photo-1706725.jpeg"
             alt="Antalya kıyı manzarası - tur temalı arka plan"
@@ -197,7 +197,7 @@ export default function Index() {
           />
           <div className="absolute inset-0 bg-gradient-to-r from-red-700/70 via-red-600/60 to-black/60" />
         </div>
-        <div className="container max-w-7xl container-px py-14 text-white">
+        <div className="container max-w-7xl container-px py-14 text-white relative z-10">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
             <div>
               <h3 className="text-2xl sm:text-3xl font-extrabold leading-tight">

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,9 +7,15 @@
 [functions]
   external_node_modules = ["express"]
   node_bundler = "esbuild"
-  
+
 [[redirects]]
   force = true
   from = "/api/*"
   status = 200
   to = "/.netlify/functions/api/:splat"
+
+# SPA fallback: route all non-file requests to index.html (keeps client-side routing working)
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Purpose

The user requested a complete rebranding of the website to use Antalya Tourbox company branding throughout the site. They specifically wanted:
- Replace all existing logos with the Antalya Tourbox logo from their website
- Update the site's color scheme to red, black, and white with red as the primary color
- Apply the new color scheme to all text styles and colors
- Add a background banner to a promotional section that was missing one

## Code Changes

- **Logo replacement**: Updated Header.tsx and Footer.tsx to use the Antalya Tourbox logo image from their website instead of the "DT" text logo
- **Color scheme overhaul**: Modified global.css to implement red/black/white color palette, changing primary colors from blue to red (HSL 0 72% 50%)
- **Background addition**: Added a beach background image to the Hero.tsx component using inline styles
- **Banner enhancement**: Updated the promotional section in Index.tsx with a proper background image and red gradient overlay
- **Branding updates**: Changed copyright text from "DreamsTour" to "Antalya Tourbox"
- **Netlify config**: Added SPA fallback redirect for client-side routing supportTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ee9a53158e9f451b96c31afe5e92e127/zen-garden)

👀 [Preview Link](https://ee9a53158e9f451b96c31afe5e92e127-zen-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ee9a53158e9f451b96c31afe5e92e127</projectId>-->
<!--<branchName>zen-garden</branchName>-->